### PR TITLE
Move download buttons to main panel

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CAIP
 Title: CAIP
-Version: 0.0.0.9003
+Version: 0.0.0.9004
 Authors@R: c(
     person("Paul", "Johnson", , "paul.johnson50@nhs.net", role = c("cre", "aut")),
     person("Ruth", "Johnson", , "ruth.johnson@nhs.net", role = "aut")

--- a/R/mod_downloads.R
+++ b/R/mod_downloads.R
@@ -12,18 +12,26 @@ mod_downloads_ui <- function(id) {
     column(
       width = 12,
       align = "left",
-      tags$p("To download the plot or the data in the tab you are currently
-             viewing, click the buttons below:")
-    ),
-    column(
-      width = 6,
-      align = "center",
-      downloadButton(outputId = ns("download_data"), label = "Download Data")
-    ),
-    column(
-      width = 6,
-      align = "center",
-      downloadButton(outputId = ns("download_plot"), label = "Download Plot")
+      tags$br(),
+      tags$p(
+        "To download the plots or the data shown in the tab you are currently
+        viewing, use the ",
+        fontawesome::fa_i(name = "download", fill_opacity = 1),
+        " buttons in the main panel."
+      ),
+      tags$br(),
+      #   tags$br(),
+      #   tags$p(
+      #     "For a detailed report about the organisation you have selected in the
+      #     dropdown filters above, including national comparisons and comparisons
+      #     with similar organisations, use the download button below:"
+      #   ),
+      #   tags$br()
+      # ),
+      # column(
+      #   width = 12,
+      #   align = "center",
+      #   downloadButton(outputId = ns("download_report"), label = "Download Report")
     ),
     column(
       width = 12,
@@ -50,120 +58,11 @@ mod_downloads_ui <- function(id) {
 #' @param input,output,session Internal parameters for {shiny}.
 #'
 #' @noRd
-mod_downloads_server <- function(id, filters_output, panel_output) {
+mod_downloads_server <- function(id, filters_res, panel_res) {
   moduleServer(
     id = id,
     function(input, output, session) {
       ns <- session$ns
-
-      filename <-
-        reactive({
-          if (filters_output$level() == "National") {
-            filters_output$level() |>
-              stringr::str_to_lower()
-          } else if (filters_output$level() == "Regional") {
-            if (filters_output$region() == "") {
-              "National" |>
-                stringr::str_to_lower()
-            } else {
-              filters_output$region() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            }
-          } else if (filters_output$level() == "ICB") {
-            if ((filters_output$icb() == "") &
-              (filters_output$region() == "")) {
-              "National" |>
-                stringr::str_to_lower()
-            } else if (filters_output$icb == "") {
-              filters_output$region() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else {
-              filters_output$icb() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            }
-          } else if (filters_output$level() == "PCN") {
-            if ((filters_output$pcn() == "") &
-              (filters_output$icb() == "") &
-              (filters_output$region() == "")) {
-              "National" |>
-                stringr::str_to_lower()
-            } else if ((filters_output$pcn() == "") &
-              (filters_output$icb() == "")) {
-              filters_output$region() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else if (filters_output$pcn() == "") {
-              filters_output$icb() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else {
-              filters_output$pcn() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            }
-          } else if (filters_output$level() == "GP Practice") {
-            if ((filters_output$practice() == "") &
-              (filters_output$pcn() == "") &
-              (filters_output$icb() == "") &
-              (filters_output$region() == "")) {
-              "National" |>
-                stringr::str_to_lower()
-            } else if ((filters_output$practice() == "") &
-              (filters_output$pcn() == "") &
-              (filters_output$icb() == "")) {
-              filters_output$region() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else if ((filters_output$practice() == "") &
-              (filters_output$pcn() == "")) {
-              filters_output$icb() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else if (filters_output$practice() == "") {
-              filters_output$pcn() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            } else {
-              filters_output$practice() |>
-                stringr::str_remove(pattern = "\\ - .*") |>
-                stringr::str_to_lower()
-            }
-          }
-        })
-
-      data <- reactive({
-        panel_output$data()
-      })
-
-      plot <- reactive({
-        panel_output$plot()
-      })
-
-      output$download_data <- downloadHandler(
-        filename = function() {
-          # Use the selected dataset as the suggested file name
-          paste0(filename(), "_gppt_data.csv")
-        },
-        content = function(file) {
-          # Write the dataset to the `file` that will be downloaded
-          readr::write_csv(data(), file)
-        }
-      )
-
-      output$download_plot <- downloadHandler(
-        filename = function() {
-          # Use the selected dataset as the suggested file name
-          paste0(filename(), "_gppt_plot.png")
-        },
-        content = function(file) {
-          # Write the dataset to the `file` that will be downloaded
-
-          ggplot2::ggsave(file, plot(), width = 20, height = 10, dpi = 320)
-        }
-      )
     }
   )
 }

--- a/R/mod_fft.R
+++ b/R/mod_fft.R
@@ -30,8 +30,37 @@ mod_fft_ui <- function(id) {
       ),
       column(
         width = 12,
+        align = "right",
+        shinyWidgets::downloadBttn(
+          outputId = ns("download_plot"),
+          label = "Download",
+          style = "material-circle",
+          color = "default",
+          size = "sm",
+          icon = fa_icon(name = "download", fill_opacity = 1)
+        )
+      ),
+      column(
+        width = 12,
         align = "center",
-        plotOutput(ns("fft_plot"), width = 1000, height = 500),
+        plotOutput(ns("fft_plot"), width = 1000, height = 500)
+      ),
+      column(
+        width = 12,
+        align = "right",
+        shinyWidgets::downloadBttn(
+          outputId = ns("download_data"),
+          label = "Download",
+          style = "material-circle",
+          color = "default",
+          size = "sm",
+          no_outline = TRUE,
+          icon = fa_icon(name = "download", fill_opacity = 1)
+        )
+      ),
+      column(
+        width = 12,
+        align = "center",
         DT::DTOutput(ns("fft_table"), width = 1000)
       )
     )
@@ -257,15 +286,109 @@ mod_fft_server <- function(id, data, filters_res) {
       )
     })
 
-    return(
-      list(
-        data = reactive({
-          fft_data()
-        }),
-        plot = reactive({
-          fft_plot()
-        })
-      )
+    org <-
+      reactive({
+        if (filters_res$level() == "National") {
+          filters_res$level() |>
+            stringr::str_to_lower()
+        } else if (filters_res$level() == "Regional") {
+          if (filters_res$region() == "") {
+            "National" |>
+              stringr::str_to_lower()
+          } else {
+            filters_res$region() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          }
+        } else if (filters_res$level() == "ICB") {
+          if ((filters_res$icb() == "") &
+            (filters_res$region() == "")) {
+            "National" |>
+              stringr::str_to_lower()
+          } else if (filters_res$icb == "") {
+            filters_res$region() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else {
+            filters_res$icb() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          }
+        } else if (filters_res$level() == "PCN") {
+          if ((filters_res$pcn() == "") &
+            (filters_res$icb() == "") &
+            (filters_res$region() == "")) {
+            "National" |>
+              stringr::str_to_lower()
+          } else if ((filters_res$pcn() == "") &
+            (filters_res$icb() == "")) {
+            filters_res$region() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else if (filters_res$pcn() == "") {
+            filters_res$icb() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else {
+            filters_res$pcn() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          }
+        } else if (filters_res$level() == "GP Practice") {
+          if ((filters_res$practice() == "") &
+            (filters_res$pcn() == "") &
+            (filters_res$icb() == "") &
+            (filters_res$region() == "")) {
+            "National" |>
+              stringr::str_to_lower()
+          } else if ((filters_res$practice() == "") &
+            (filters_res$pcn() == "") &
+            (filters_res$icb() == "")) {
+            filters_res$region() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else if ((filters_res$practice() == "") &
+            (filters_res$pcn() == "")) {
+            filters_res$icb() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else if (filters_res$practice() == "") {
+            filters_res$pcn() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          } else {
+            filters_res$practice() |>
+              stringr::str_remove(pattern = "\\ - .*") |>
+              stringr::str_to_lower()
+          }
+        }
+      })
+
+    yrs <- reactive({
+      paste0(input$date_range[1], "-", input$date_range[2])
+    })
+
+    output$download_data <- downloadHandler(
+      filename = function() {
+        # Use the selected dataset as the suggested file name
+        paste0("fft-", org(), "-", yrs(), ".csv")
+      },
+      content = function(file) {
+        # Write the dataset to the `file` that will be downloaded
+        readr::write_csv(fft_data(), file)
+      }
+    )
+
+    output$download_plot <- downloadHandler(
+      filename = function() {
+        # Use the selected dataset as the suggested file name
+        paste0("fft-", org(), "-", yrs(), ".png")
+      },
+      content = function(file) {
+        # Write the dataset to the `file` that will be downloaded
+
+        ggplot2::ggsave(file, fft_plot(), width = 20, height = 10, dpi = 320)
+      }
     )
   })
 }

--- a/R/mod_filters.R
+++ b/R/mod_filters.R
@@ -22,6 +22,7 @@ mod_filters_ui <- function(id) {
       tags$p("Select the level at which you want to aggregate the GPPT and FFT
              responses, before choosing any filters needed for the data that you
              are interested in."),
+      tags$br(),
       selectInput(
         inputId = ns("level"),
         label = "Level",

--- a/R/utils.R
+++ b/R/utils.R
@@ -43,8 +43,9 @@ reset_monthday <- function(date) {
 #'
 #' @param name The name of the icon taken from the font awesome website
 #' (https://fontawesome.com/icons)
+#' @param fill_opacity
 #'
 #' @noRd
-fa_icon <- function(name) {
-  fontawesome::fa(name = name, fill = "#231F20", fill_opacity = .8)
+fa_icon <- function(name, fill_opacity = 0.8) {
+  fontawesome::fa(name = name, fill = "#231F20", fill_opacity = fill_opacity)
 }

--- a/manifest.json
+++ b/manifest.json
@@ -4618,7 +4618,7 @@
       "checksum": "ba63a3aea2a1d0d92c1c2f2760463e8a"
     },
     ".Rprofile": {
-      "checksum": "5664d8b7a3ef9ac0f5f24a80ff02cbd1"
+      "checksum": "723ec901b4198d7dc81bda2ba8eccd87"
     },
     "app.R": {
       "checksum": "57a5e4d5e53e1fa19289783240029906"
@@ -4669,7 +4669,7 @@
       "checksum": "19d7ea048e1f9832a06f85fd7afe4b84"
     },
     "DESCRIPTION": {
-      "checksum": "1419e292f4890407ba656cd5619c4816"
+      "checksum": "dd1ad25dcdd42ca4b248fefffcca2144"
     },
     "dev/01_start.R": {
       "checksum": "ee6b53b21f38afac226d2c0bec62bf5c"
@@ -4690,10 +4690,10 @@
       "checksum": "54b6cb3d2914363b6df1276b37cc6fe9"
     },
     "inst/app/www/about.html": {
-      "checksum": "e39daee432cd5d31b9933872251f2d00"
+      "checksum": "ee49f039a320f1adfb14748fa838b227"
     },
     "inst/app/www/about.Rmd": {
-      "checksum": "105022f497ee821b9548a071e5434e37"
+      "checksum": "0b3af6e87e1fa51c9bd2e9efe81f0f11"
     },
     "inst/app/www/custom.css": {
       "checksum": "d41d8cd98f00b204e9800998ecf8427e"
@@ -4792,25 +4792,25 @@
       "checksum": "e0b7c9c2f032eb0c4962c5b447f02620"
     },
     "R/mod_about.R": {
-      "checksum": "4489590bbf30b2894115cc5d678f24a5"
+      "checksum": "bea8f81af09cf41825f311020e8c69ce"
     },
     "R/mod_downloads.R": {
-      "checksum": "47a226e465c06289bf8c0bd2de80511c"
+      "checksum": "f865b712fe24633a315362ab1ae447b4"
     },
     "R/mod_fft.R": {
-      "checksum": "edfe3619970bc5970a67cab9f7d6f904"
+      "checksum": "9f4b63fa2ad41aeaab1ccb3c1dd728f6"
     },
     "R/mod_filters.R": {
-      "checksum": "1599dfa45d7eadeeb1a20a1d819c1872"
+      "checksum": "987027cd7027c469e0f0c52d06800fba"
     },
     "R/mod_gppt.R": {
-      "checksum": "e958e5ec979e4ff08d831f5129164f26"
+      "checksum": "393a69c842ac12b92206a74eb68c421e"
     },
     "R/run_app.R": {
       "checksum": "0fd85883945a42f68b8fc9a2700bc6cc"
     },
     "R/utils.R": {
-      "checksum": "7239ea773bba68c567970a28346ed0cf"
+      "checksum": "8e4636f9548ffeb4c752c33ba0bf45ae"
     },
     "README.md": {
       "checksum": "fc078e391cc107e8bfb64e11c4cbb41f"
@@ -4852,7 +4852,7 @@
       "checksum": "d100ad8441b0893ddb8435b069d83226"
     },
     "tests/testthat/test-mod_about.R": {
-      "checksum": "f1f203d5f49f7931f616660b4621484f"
+      "checksum": "4209dfb6fc26e68fb5130220522978db"
     },
     "tests/testthat/test-mod_downloads.R": {
       "checksum": "a254ef6403285af87f2f5ec3ad762710"
@@ -4864,7 +4864,7 @@
       "checksum": "b7dfcae205b21c7cc6d50e0b2a7ba1ff"
     },
     "tests/testthat/test-mod_gppt.R": {
-      "checksum": "af494eb5e16fddcefe2fae288fac8f02"
+      "checksum": "fb9deab618406fa3d082b9d6d4483aaf"
     },
     "tests/testthat/test-utils.R": {
       "checksum": "2c52ad69546bcfdbd03cab9e9d0ef859"


### PR DESCRIPTION
I've moved the download buttons from the sidebar panel to the main panel, with each plot and table in the GPPT and FFT tabs having a button that downloads the object that is being displayed at that time. 

This has also reduced the complexity of the app, as there are no longer interactions required between multiple modules just to download the plots or tables in the app. However, this complexity will probably be reintroduced once a parameterized report has been developed and can be downloaded in the app. 